### PR TITLE
Fix graalvm/README.md jar filename

### DIFF
--- a/graalvm/README.md
+++ b/graalvm/README.md
@@ -12,7 +12,7 @@ There is a dependency, however, on the underlying server platform to also not us
 
 ```shell script
 ./gradlew test shadowJar
-java -jar build/libs/Example-all.jar
+java -jar build/libs/example.jar
 ```
 
 then:


### PR DESCRIPTION
Hi!

I was playing a bit with the graalvm example, but found that one of the commands in the README uses the wrong file name for the jar that is built.

Might be useful to someone else to get started.

<img width="473" alt="image" src="https://github.com/http4k/examples/assets/32980192/62753b3a-8508-432f-b4ff-d6d85ef6fa8f">
